### PR TITLE
pytest: Add cmd options to show skip reasons

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ timeout = 35
 addopts =
     --color=yes
     --doctest-glob=*.rst
+    -r s
     --ignore=coalib/tests/collecting/collectors_test_dir/bears/incorrect_bear.py
 env =
     PYTHONHASHSEED=0


### PR DESCRIPTION
`-r s` shows more information about why a test has been
skipped. This is useful information and needs to be shown.

Fixes https://github.com/coala-analyzer/coala/issues/1623
